### PR TITLE
Bottom nav bar should depend on flag

### DIFF
--- a/lib/src/viewer.dart
+++ b/lib/src/viewer.dart
@@ -225,7 +225,7 @@ class _PDFViewerState extends State<PDFViewer> {
             )
           : null,
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
-      bottomNavigationBar: widget.showNavigation
+      bottomNavigationBar: (widget.showNavigation && widget.document.count > 1)
           ? widget.navigationBuilder != null
               ? widget.navigationBuilder(
                   context,
@@ -298,7 +298,7 @@ class _PDFViewerState extends State<PDFViewer> {
                     ],
                   ),
                 )
-          : null,
+          : Container(),
     );
   }
 }

--- a/lib/src/viewer.dart
+++ b/lib/src/viewer.dart
@@ -225,7 +225,7 @@ class _PDFViewerState extends State<PDFViewer> {
             )
           : null,
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
-      bottomNavigationBar: (widget.showNavigation || widget.document.count > 1)
+      bottomNavigationBar: widget.showNavigation
           ? widget.navigationBuilder != null
               ? widget.navigationBuilder(
                   context,
@@ -298,7 +298,7 @@ class _PDFViewerState extends State<PDFViewer> {
                     ],
                   ),
                 )
-          : Container(),
+          : null,
     );
   }
 }


### PR DESCRIPTION
Fixing an issue where settings `showNavigation` to false didn't do anything.

Similar bug on forked repo https://github.com/CrossPT/flutter_plugin_pdf_viewer/issues/57