### PR TITLE
Fix pre-built code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,16 +44,16 @@ PDFPage pageOne = await doc.get(page: _number);
 #### Pre-built viewer
 Use the pre-built PDF Viewer
 ```
-@override
+  @override
   Widget build(BuildContext context) {
-    Scaffold(
-        appBar: AppBar(
-          title: Text('Example'),
-        ),
-        body: Center(
-        child: _isLoading
-            ? Center(child: CircularProgressIndicator())
-            : PDFViewer(document: document)),
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Example'),
+      ),
+      body: Center(
+          child: _isLoading
+              ? Center(child: CircularProgressIndicator())
+              : PDFViewer(document: document)),
     );
   }
 ```


### PR DESCRIPTION
This PR attempts to fix the example pre-built dart code in README.md which has missing return and other formatting related issues.