### PR TITLE
iOS: Fix bug where file paths containing whitespace cannot be opened

### DIFF
--- a/ios/Classes/FlutterPluginPdfViewerPlugin.m
+++ b/ios/Classes/FlutterPluginPdfViewerPlugin.m
@@ -1,7 +1,6 @@
 #import "FlutterPluginPdfViewerPlugin.h"
 
 static NSString* const kDirectory = @"FlutterPluginPdfViewer";
-static NSString* const kFilePath = @"file:///";
 static NSString* kFileName = @"";
 
 @implementation FlutterPluginPdfViewerPlugin
@@ -31,12 +30,7 @@ static NSString* kFileName = @"";
 
 -(NSString *)getNumberOfPages:(NSString *)url
 {
-    NSURL * sourcePDFUrl;
-    if([url containsString:kFilePath]){
-        sourcePDFUrl = [NSURL URLWithString:url];
-    }else{
-        sourcePDFUrl = [NSURL URLWithString:[kFilePath stringByAppendingString:url]];
-    }
+    NSURL * sourcePDFUrl = [[NSURL alloc] initFileURLWithPath:url];
     CGPDFDocumentRef SourcePDFDocument = CGPDFDocumentCreateWithURL((__bridge CFURLRef)sourcePDFUrl);
     size_t numberOfPages = CGPDFDocumentGetNumberOfPages(SourcePDFDocument);
     NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
@@ -68,12 +62,7 @@ static NSString* kFileName = @"";
 
 -(NSString*)getPage:(NSString *)url ofPage:(size_t)pageNumber
 {
-    NSURL * sourcePDFUrl;
-    if([url containsString:kFilePath]){
-        sourcePDFUrl = [NSURL URLWithString:url];
-    }else{
-        sourcePDFUrl = [NSURL URLWithString:[kFilePath stringByAppendingString:url]];
-    }
+    NSURL * sourcePDFUrl = [[NSURL alloc] initFileURLWithPath:url];
     CGPDFDocumentRef SourcePDFDocument = CGPDFDocumentCreateWithURL((__bridge CFURLRef)sourcePDFUrl);
     size_t numberOfPages = CGPDFDocumentGetNumberOfPages(SourcePDFDocument);
     NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);

--- a/ios/Classes/FlutterPluginPdfViewerPlugin.m
+++ b/ios/Classes/FlutterPluginPdfViewerPlugin.m
@@ -31,8 +31,9 @@ static NSString* kFileName = @"";
 -(NSString *)getNumberOfPages:(NSString *)url
 {
     NSURL * sourcePDFUrl = [[NSURL alloc] initFileURLWithPath:url];
-    CGPDFDocumentRef SourcePDFDocument = CGPDFDocumentCreateWithURL((__bridge CFURLRef)sourcePDFUrl);
-    size_t numberOfPages = CGPDFDocumentGetNumberOfPages(SourcePDFDocument);
+    CGPDFDocumentRef sourcePDFDocument = CGPDFDocumentCreateWithURL((__bridge CFURLRef)sourcePDFUrl);
+    size_t numberOfPages = CGPDFDocumentGetNumberOfPages(sourcePDFDocument);
+    CGPDFDocumentRelease(sourcePDFDocument);
     NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
     NSString *temporaryDirectory = [paths objectAtIndex:0];
     NSString *filePathAndDirectory = [temporaryDirectory stringByAppendingPathComponent:kDirectory];
@@ -63,8 +64,8 @@ static NSString* kFileName = @"";
 -(NSString*)getPage:(NSString *)url ofPage:(size_t)pageNumber
 {
     NSURL * sourcePDFUrl = [[NSURL alloc] initFileURLWithPath:url];
-    CGPDFDocumentRef SourcePDFDocument = CGPDFDocumentCreateWithURL((__bridge CFURLRef)sourcePDFUrl);
-    size_t numberOfPages = CGPDFDocumentGetNumberOfPages(SourcePDFDocument);
+    CGPDFDocumentRef sourcePDFDocument = CGPDFDocumentCreateWithURL((__bridge CFURLRef)sourcePDFUrl);
+    size_t numberOfPages = CGPDFDocumentGetNumberOfPages(sourcePDFDocument);
     NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
     NSString *temporaryDirectory = [paths objectAtIndex:0];
     NSString *filePathAndDirectory = [temporaryDirectory stringByAppendingPathComponent:kDirectory];
@@ -82,11 +83,11 @@ static NSString* kFileName = @"";
         NSLog(@"Create directory error: %@", error);
         return nil;
     }
-    CGPDFPageRef SourcePDFPage = CGPDFDocumentGetPage(SourcePDFDocument, pageNumber);
-    CGPDFPageRetain(SourcePDFPage);
+    CGPDFPageRef sourcePDFPage = CGPDFDocumentGetPage(sourcePDFDocument, pageNumber);
+    CGPDFPageRetain(sourcePDFPage);
     NSString *relativeOutputFilePath = [NSString stringWithFormat:@"%@/%@-%d.png", kDirectory, kFileName, (int)pageNumber];
     NSString *imageFilePath = [temporaryDirectory stringByAppendingPathComponent:relativeOutputFilePath];
-    CGRect sourceRect = CGPDFPageGetBoxRect(SourcePDFPage, kCGPDFMediaBox);
+    CGRect sourceRect = CGPDFPageGetBoxRect(sourcePDFPage, kCGPDFMediaBox);
     UIGraphicsBeginPDFContextToFile(imageFilePath, sourceRect, nil);
     // Calculate resolution
     // Set DPI to 300
@@ -104,11 +105,13 @@ static NSString* kFileName = @"";
     CGContextTranslateCTM(currentContext, 0.0, height);
     CGContextScaleCTM(currentContext, dpi, -dpi);
     CGContextSaveGState(currentContext);
-    CGContextDrawPDFPage (currentContext, SourcePDFPage);
+    CGContextDrawPDFPage (currentContext, sourcePDFPage);
     CGContextRestoreGState(currentContext);
     UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
     [UIImagePNGRepresentation(image) writeToFile: imageFilePath atomically:YES];
+    CGPDFPageRelease(sourcePDFPage);
+    CGPDFDocumentRelease(sourcePDFDocument);
     return imageFilePath;
 }
 


### PR DESCRIPTION
Use initFileURLWithPath to create a valid file path

The NSURL init method initFileURLWithPath will ensure that the `file:///` prefix is in place
as well as making sure that any whitespace characters within the original path string
are encoded correctly when creating the url.

This should address the following issues:

- #29
- #57

This PR also improves memory management within the iOS native side by releasing the [retained `CGPDFDocument`](https://developer.apple.com/documentation/coregraphics/1402585-cgpdfdocumentcreatewithurl?language=objc) and `CGPDFPage` instances.