### PR TITLE
fixes #96 #100

### DIFF
--- a/android/src/main/java/pt/tribeiro/flutter_plugin_pdf_viewer/FlutterPluginPdfViewerPlugin.java
+++ b/android/src/main/java/pt/tribeiro/flutter_plugin_pdf_viewer/FlutterPluginPdfViewerPlugin.java
@@ -85,13 +85,14 @@ public class FlutterPluginPdfViewerPlugin implements FlutterPlugin, MethodCallHa
                                 if (pageResult == null) {
                                     Log.d(TAG, "Retrieving page failed.");
                                     result.notImplemented();
+                                } else {
+                                    mainThreadHandler.post(new Runnable() {
+                                        @Override
+                                        public void run() {
+                                            result.success(pageResult);
+                                        }
+                                    });
                                 }
-                                mainThreadHandler.post(new Runnable() {
-                                    @Override
-                                    public void run() {
-                                        result.success(pageResult);
-                                    }
-                                });
                                 break;
                             default:
                                 result.notImplemented();
@@ -200,7 +201,6 @@ public class FlutterPluginPdfViewerPlugin implements FlutterPlugin, MethodCallHa
                 ret = createTempPreview(bitmap, filePath, pageNumber);
             } finally {
                 page.close();
-                renderer.close();
             }
             return ret;
         } catch (Exception ex) {


### PR DESCRIPTION
There are reports of a crash happening with newer versions of flutter (issues #96 and #100).
This pull request aims to solve the crash.

Explanation of the changes:
- The `renderer.close()` in `getPage `sometimes creates an exception. It is because the close is already preformed by the try-catch clause itself. The code `renderer.close()` can therefore be safely removed.
- A else block has been added because it was missing (e.g. `result ` should not been used twice).
